### PR TITLE
main.py option to pick detected label and isolate it

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Training data can be downloaded [here](https://www.upf.edu/web/mtg/irmas) and sh
 ## Usage
 `py main.py -p <path>`
 Use the optional flag `-b` to force rebuilding the model.
-To isolate an instrument, use the flag -i followed by the three-letter tag for that instrument (eg. trumpet becomes 'tru'). You may additionally add the -n flag to specify which audio file you'd like to isolate an instrument from.
+To show predictions for all files in the data folder, use the `-a` argument.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Training data can be downloaded [here](https://www.upf.edu/web/mtg/irmas) and sh
 ## Usage
 `py main.py -p <path>`
 Use the optional flag `-b` to force rebuilding the model.
+To isolate an instrument, use the flag -i followed by the three-letter tag for that instrument (eg. trumpet becomes 'tru'). You may additionally add the -n flag to specify which audio file you'd like to isolate an instrument from.

--- a/src/isolate.py
+++ b/src/isolate.py
@@ -62,7 +62,7 @@ def main():
     label = 'tru'
     data_dir = 'training_data'
     input_file_path = os.path.join(data_dir, label, '[tru][cla]1870__1.wav')
-    isolate('tru', input_file_path)
+    isolate(label, input_file_path)
 
 if __name__ == '__main__':
     main()

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import os
 import train
 import argparse
+from isolate import isolate
 
 import numpy as np
 import tensorflow as tf
@@ -14,29 +15,18 @@ from util import SAMPLE_SIZE, STEP_SIZE, LABELS, transform
 
 def parse_args():
     parser = argparse.ArgumentParser(description="An AI that detects the instruments playing in a sample")
-    parser.add_argument('-p', '--path', type=str, help='Input file path', required=True)
+    parser.add_argument('-p', '--path', type=str, help='Input file path')
     parser.add_argument('-b', '--build', action='store_true', help='Force build the model, even if one already exists')
+    parser.add_argument('-i', '--isolate', type=str, help='Three-letter string denoting the instrument to be isolated')
+    parser.add_argument('-n', '--name', type=str, help='The name of the file to isolate sound of. For use with -f')
     args = parser.parse_args()
     return args
     
 def load_keras_model():
     model: Sequential = load_model('saved_model')
     return model
-
-def main():
-    args = parse_args()
-    # Whatever we want to do with that path
-    # print(args.path)
     
-    if (args.build):
-        train.main()
-    
-    try:
-        model = load_keras_model()
-    except:
-        train.main()
-        model = load_keras_model()
-
+def predict_files(model):
     data_dir = "testing_data"
     files = os.listdir(data_dir)
     
@@ -86,7 +76,35 @@ def main():
         for i, average in enumerate(averages):
             if average > 0.2:
                 print(LABELS[i])
+                
+def isolate_instrument(label, name):
+    data_dir = 'training_data'
+    input_file_path = os.path.join(data_dir, label, '[tru][cla]1870__1.wav')
+    isolate(label, input_file_path)
 
+def main():
+    args = parse_args()
+    # Whatever we want to do with that path
+    # print(args.path)
+    
+    if (args.build):
+        train.main()
+    
+    try:
+        model = load_keras_model()
+    except:
+        train.main()
+        model = load_keras_model()
+
+    if (args.isolate is None or args.isolate == ''):
+        predict_files(model)
+        return
+    
+    name = '[tru][cla]1870__1.wav'
+    if not (args.name is None or args.name == ''):
+        name = args.name
+    isolate_instrument(args.isolate, name)
+    
 if __name__ == "__main__":
     main()
     

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,6 @@ def parse_args():
     parser.add_argument('-p', '--path', type=str, help='Input file path')
     parser.add_argument('-b', '--build', action='store_true', help='Force build the model, even if one already exists')
     parser.add_argument('-i', '--isolate', type=str, help='Three-letter string denoting the instrument to be isolated')
-    parser.add_argument('-n', '--name', type=str, help='The name of the file to isolate sound of. For use with -f')
     args = parser.parse_args()
     return args
     
@@ -76,34 +75,31 @@ def predict_files(model):
         for i, average in enumerate(averages):
             if average > 0.2:
                 print(LABELS[i])
-                
-def isolate_instrument(label, name):
-    data_dir = 'training_data'
-    input_file_path = os.path.join(data_dir, label, '[tru][cla]1870__1.wav')
-    isolate(label, input_file_path)
 
 def main():
     args = parse_args()
-    # Whatever we want to do with that path
-    # print(args.path)
     
+    # Build the model if requested
     if (args.build):
         train.main()
     
+    # If the model does not already exist, build it first
     try:
         model = load_keras_model()
     except:
         train.main()
         model = load_keras_model()
 
+    # If we don't specify we want to isolate an instrument, we run the prediction
     if (args.isolate is None or args.isolate == ''):
         predict_files(model)
         return
     
-    name = '[tru][cla]1870__1.wav'
-    if not (args.name is None or args.name == ''):
-        name = args.name
-    isolate_instrument(args.isolate, name)
+    # Otherwise, we isolate the requested instrument from the requested file. Here's a sample file from the data set that can quickly be used as a default.
+    input_file_path = os.path.join('training_data', args.isolate, '[tru][cla]1870__1.wav')
+    if not (args.path is None or args.path == ''):
+        input_file_path = args.path
+    isolate(args.isolate, input_file_path)
     
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Sample usage:
`py main.py -p <path>`
Skip the -p and it has a default file to apply to.
You can use the `-a` argument to make predictions for all files.